### PR TITLE
Refactoring of preprocess_flatfield and test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
           C_INCLUDE_PATH: /usr/include/cfitsio/
     - name: Test
       run: |
-        source setup_local_crds.sh && pytest -v liger_iris_pipeline/tests/test_datamodels.py liger_iris_pipeline/tests/test_dark.py liger_iris_pipeline/tests/test_rop.py liger_iris_pipeline/tests/test_utils.py liger_iris_pipeline/tests/test_normalize.py liger_iris_pipeline/tests/test_assign_wcs.py liger_iris_pipeline/tests/test_asdf_schema.py
+        source setup_local_crds.sh && pytest -v liger_iris_pipeline/tests/test_datamodels.py liger_iris_pipeline/tests/test_dark.py liger_iris_pipeline/tests/test_rop.py liger_iris_pipeline/tests/test_utils.py liger_iris_pipeline/tests/test_normalize.py liger_iris_pipeline/tests/test_assign_wcs.py liger_iris_pipeline/tests/test_asdf_schema.py liger_iris_pipeline/tests/test_preprocess_flatfield.py
         #- name: Build docs
         #  if: ${{ matrix.python-version==3.11 }}
         #  run: |

--- a/liger_iris_pipeline/dark_current/dark_current_step.py
+++ b/liger_iris_pipeline/dark_current/dark_current_step.py
@@ -25,7 +25,7 @@ class DarkCurrentStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.LigerIrisDataModel(input) as input_model:
+        with self.open_model(input) as input_model:
 
             # Get the name of the dark reference file to use
             self.dark_name = self.get_reference_file(input_model, "dark")

--- a/liger_iris_pipeline/pipeline/preprocess_flatfield.py
+++ b/liger_iris_pipeline/pipeline/preprocess_flatfield.py
@@ -101,7 +101,6 @@ class ProcessFlatfieldL2(Pipeline):
         # Record ASN pool and table names in output
         input.meta.asn.pool_name = pool_name
         input.meta.asn.table_name = asn_file
-
         input = self.dark_current(input)
         input = self.normalize(input)
 

--- a/liger_iris_pipeline/pipeline/preprocess_flatfield.py
+++ b/liger_iris_pipeline/pipeline/preprocess_flatfield.py
@@ -93,7 +93,7 @@ class ProcessFlatfieldL2(Pipeline):
         science = science[0]
 
         self.log.info("Working on input %s ...", science)
-        if isinstance(science, datamodels.DataModel):
+        if isinstance(science, datamodels.JwstDataModel):
             input = science
         else:
             input = datamodels.open(science)

--- a/liger_iris_pipeline/tests/test_assign_wcs.py
+++ b/liger_iris_pipeline/tests/test_assign_wcs.py
@@ -13,7 +13,7 @@ from astropy.tests.helper import assert_quantity_allclose
 
 def test_assign_wcs_step():
     # Grab simulated raw frame
-    raw_science_filename = get_data_from_url("47090569")
+    raw_science_filename = get_data_from_url("48191524")
     input_model = datamodels.open(raw_science_filename)
 
     # Ensure we haven't already performed the correction.

--- a/liger_iris_pipeline/tests/test_dark.py
+++ b/liger_iris_pipeline/tests/test_dark.py
@@ -8,7 +8,7 @@ from liger_iris_pipeline.dark_current.dark_sub import do_correction
 
 def test_dark_subtraction():
     # Grab simulated raw frame
-    raw_science_filename = get_data_from_url("47090569")
+    raw_science_filename = get_data_from_url("48191524")
     input_model = datamodels.open(raw_science_filename)
 
     # Create a dark image with randomized vals centered around zero
@@ -22,7 +22,7 @@ def test_dark_subtraction():
     np.testing.assert_allclose(output.data, expected_output_data)
 
 def test_dark_step():
-    raw_science_filename = get_data_from_url("47090569")
+    raw_science_filename = get_data_from_url("48191524")
     input_model = datamodels.open(raw_science_filename)
 
     # Test DarkCurrentStep class

--- a/liger_iris_pipeline/tests/test_datamodels.py
+++ b/liger_iris_pipeline/tests/test_datamodels.py
@@ -5,7 +5,7 @@ from liger_iris_pipeline.datamodels import LigerIrisImageModel
 
 def test_load_iris_image_file():
 
-    raw_science_filename = get_data_from_url("17903858")
+    raw_science_filename = get_data_from_url("48191524")
 
     input_model = LigerIrisImageModel(raw_science_filename)
 

--- a/liger_iris_pipeline/tests/test_preprocess_flatfield.py
+++ b/liger_iris_pipeline/tests/test_preprocess_flatfield.py
@@ -1,82 +1,37 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-# In[ ]:
-
-
+# Imports
 import liger_iris_pipeline
-
-
-# In[ ]:
-
-
-# check where are we loading the library from
-liger_iris_pipeline.__file__
-
-
-# In[ ]:
-
-
+liger_iris_pipeline.monkeypatch_jwst_datamodels()
 import numpy as np
-
-
-# In[ ]:
-
-
-from test_utils import get_data_from_url
-
-
-# In[ ]:
-
-
+from astropy.io import fits
+from liger_iris_pipeline.tests.test_utils import get_data_from_url
 from jwst import datamodels
 
+def test_process_flatfield():
 
-# In[ ]:
+    # Grab raw science
+    raw_science_filename = get_data_from_url("17903858")
+    with fits.open(raw_science_filename, output_verify='fix', mode='update') as f:
+        f[0].header['DATAMODL'] = 'LigerIrisImageModel'
+        if len(f[0].header['DATE']) > 22:
+            f[0].header['DATE'] = f[0].header['DATE'][:22]
+    input_model = datamodels.open(raw_science_filename)
 
+    # Initialize flatfield pipeline
+    pipeline = liger_iris_pipeline.pipeline.ProcessFlatfieldL2()
 
-raw_science_filename = get_data_from_url("17903858")
+    # Run pipeline
+    pipeline_output = pipeline.run(raw_science_filename)
 
+    breakpoint()
 
-# In[ ]:
+    # Open dark
+    dark_current = datamodels.open(pipeline_output[0].dark_current.dark_name)
 
+    # Manually create a master flat
+    expected = input_model.data - dark_current.data
+    expected /= np.median(expected)
 
-input_model = datamodels.open(raw_science_filename)
+    # Test
+    np.testing.assert_allclose(dark_current[0].data, expected)
 
-
-# In[ ]:
-
-
-input_model
-
-
-# In[ ]:
-
-
-step = liger_iris_pipeline.pipeline.ProcessFlatfieldL2()
-
-
-# In[ ]:
-
-
-step_output = step.run(raw_science_filename)
-
-
-# In[ ]:
-
-
-dark_current = datamodels.open(step.dark_current.dark_name)
-
-
-# In[ ]:
-
-
-expected = input_model.data - dark_current.data
-expected /= np.median(expected)
-
-
-# In[ ]:
-
-
-np.testing.assert_allclose(step_output[0].data, expected)
-
+test_process_flatfield()

--- a/liger_iris_pipeline/tests/test_preprocess_flatfield.py
+++ b/liger_iris_pipeline/tests/test_preprocess_flatfield.py
@@ -8,30 +8,22 @@ from jwst import datamodels
 
 def test_process_flatfield():
 
-    # Grab raw science
-    raw_science_filename = get_data_from_url("17903858")
-    with fits.open(raw_science_filename, output_verify='fix', mode='update') as f:
-        f[0].header['DATAMODL'] = 'LigerIrisImageModel'
-        if len(f[0].header['DATE']) > 22:
-            f[0].header['DATE'] = f[0].header['DATE'][:22]
-    input_model = datamodels.open(raw_science_filename)
+    # Grab flat field
+    raw_flat_filename = get_data_from_url("48191521")
+    input_model = datamodels.open(raw_flat_filename)
 
     # Initialize flatfield pipeline
     pipeline = liger_iris_pipeline.pipeline.ProcessFlatfieldL2()
 
     # Run pipeline
-    pipeline_output = pipeline.run(raw_science_filename)
-
-    breakpoint()
+    pipeline_output = pipeline.run(raw_flat_filename)
 
     # Open dark
-    dark_current = datamodels.open(pipeline_output[0].dark_current.dark_name)
+    dark_current = datamodels.open(pipeline.dark_current.dark_name)
 
-    # Manually create a master flat
+    # Manually create a dark subtracted master flat
     expected = input_model.data - dark_current.data
     expected /= np.median(expected)
 
     # Test
-    np.testing.assert_allclose(dark_current[0].data, expected)
-
-test_process_flatfield()
+    np.testing.assert_allclose(pipeline_output[0].data, expected)

--- a/liger_iris_pipeline/tests/test_rop.py
+++ b/liger_iris_pipeline/tests/test_rop.py
@@ -1,6 +1,6 @@
 import os
 import liger_iris_pipeline
-
+from liger_iris_pipeline.tests.test_utils import get_data_from_url
 liger_iris_pipeline.monkeypatch_jwst_datamodels()
 import numpy as np
 
@@ -60,8 +60,9 @@ def setup_inputs(
 
 
 def test_rop1():
+    raw_readout_filename = get_data_from_url("48191977")
     liger_iris_pipeline.pipeline.ROPPipeline.call(
-        "liger_iris_pipeline/tests/data/test_ramp.fits", config_file="liger_iris_pipeline/tests/data/drsrop.cfg"
+        raw_readout_filename, config_file="liger_iris_pipeline/tests/data/drsrop.cfg"
     )
     return 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astropy>=6.1.0
 Cython>=3.0.10
 numpy>=1.26.4,<2
-jwst>=1.14.0
-stpipe>=0.5.2
-stdatamodels>=1.10.1
+jwst>=1.15.1
+stpipe>=0.6.0
+stdatamodels>=2.0.0
 crds @ git+https://github.com/oirlab/liger_iris_crds@master


### PR DESCRIPTION
@zonca Updates while working on `ProcessFlatfieldL2`:

1. I updated the header values DATAMODL and DATE just [within the test ](https://github.com/oirlab/liger_iris_pipeline/blob/813ec8be58311e64ece969405e7d0a98945993bc/liger_iris_pipeline/tests/test_preprocess_flatfield.py#L13-L16)for now. Should I upload a new file to figshare? This file (17903858) is used in several other tests.
2. The current error for `ProcessFlatfieldL2` is this line https://github.com/oirlab/liger_iris_pipeline/blob/813ec8be58311e64ece969405e7d0a98945993bc/liger_iris_pipeline/normalize/normalize.py#L83

because `output` has no attribute `err`. This is because within `DarkCurrentStep` (the first step in `ProcessFlatfieldL2`) we explicitly use https://github.com/oirlab/liger_iris_pipeline/blob/813ec8be58311e64ece969405e7d0a98945993bc/liger_iris_pipeline/dark_current/dark_current_step.py#L28

which returns a data model with no `err` attribute. Digging deeper, I believe the jwst pipeline directly uses the `RampModel`:

https://github.com/spacetelescope/jwst/blob/e34f4d844c6fa4d798498cfc17f384f834f43333/jwst/dark_current/dark_current_step.py#L29

because [jwst performs the dark subtraction on individual reads](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/stages-of-jwst-data-processing/calwebb_detector1#gsc.tab=0). I *think* this is because readout induces an additional dark current signal, so it's trying correct that for each readout.

I don't think we should go down that rabbit hole yet. Instead for now, I suggest we go back to the general method `Step.open_model`. I created a local MWE and this does solve the issue.

Let me know your thoughts!